### PR TITLE
Move ConcatSpaceFixer since it's a Symfony specific rule

### DIFF
--- a/config/whatwedo-common.php
+++ b/config/whatwedo-common.php
@@ -132,9 +132,9 @@ return static function (ECSConfig $ecsConfig): void {
         ReferenceUsedNamesOnlySniff::class => null,
         UselessVariableSniff::class => null,
 
-        ClassCommentSniff::class.'.Missing' => null,
-        FileCommentSniff::class.'.Missing' => null,
-        FileCommentSniff::class.'.WrongStyle' => null,
+        ClassCommentSniff::class . '.Missing' => null,
+        FileCommentSniff::class . '.Missing' => null,
+        FileCommentSniff::class . '.WrongStyle' => null,
         ValidClassNameSniff::class => ['**/whatwedo*.php'],
     ]);
 

--- a/config/whatwedo-common.php
+++ b/config/whatwedo-common.php
@@ -17,7 +17,6 @@ use PhpCsFixer\Fixer\ControlStructure\NoTrailingCommaInListCallFixer;
 use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\IsNullFixer;
 use PhpCsFixer\Fixer\NamespaceNotation\BlankLineAfterNamespaceFixer;
-use PhpCsFixer\Fixer\Operator\ConcatSpaceFixer;
 use PhpCsFixer\Fixer\Operator\IncrementStyleFixer;
 use PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer;
 use PhpCsFixer\Fixer\Operator\OperatorLinebreakFixer;
@@ -78,9 +77,6 @@ return static function (ECSConfig $ecsConfig): void {
             'phpunit',
             'magic',
         ],
-    ]);
-    $ecsConfig->ruleWithConfiguration(ConcatSpaceFixer::class, [
-        'spacing' => 'none',
     ]);
     $ecsConfig->rule(NoImportFromGlobalNamespaceFixer::class);
     $ecsConfig->rule(NoNullableBooleanTypeFixer::class);

--- a/config/whatwedo-symfony.php
+++ b/config/whatwedo-symfony.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use Symplify\EasyCodingStandard\Config\ECSConfig;
-use PhpCsFixerCustomFixers\Fixer\NoDoctrineMigrationsGeneratedCommentFixer;
 use PhpCsFixer\Fixer\Operator\ConcatSpaceFixer;
+use PhpCsFixerCustomFixers\Fixer\NoDoctrineMigrationsGeneratedCommentFixer;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return static function (ECSConfig $ecsConfig): void {
-    $ecsConfig->sets([__DIR__.'/whatwedo-common.php']);
+    $ecsConfig->sets([__DIR__ . '/whatwedo-common.php']);
     $ecsConfig->rule(NoDoctrineMigrationsGeneratedCommentFixer::class);
     $ecsConfig->ruleWithConfiguration(ConcatSpaceFixer::class, [
         'spacing' => 'none',

--- a/config/whatwedo-symfony.php
+++ b/config/whatwedo-symfony.php
@@ -2,10 +2,14 @@
 
 declare(strict_types=1);
 
-use PhpCsFixerCustomFixers\Fixer\NoDoctrineMigrationsGeneratedCommentFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
+use PhpCsFixerCustomFixers\Fixer\NoDoctrineMigrationsGeneratedCommentFixer;
+use PhpCsFixer\Fixer\Operator\ConcatSpaceFixer;
 
 return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->sets([__DIR__.'/whatwedo-common.php']);
     $ecsConfig->rule(NoDoctrineMigrationsGeneratedCommentFixer::class);
+    $ecsConfig->ruleWithConfiguration(ConcatSpaceFixer::class, [
+        'spacing' => 'none',
+    ]);
 };

--- a/config/whatwedo-wordpress.php
+++ b/config/whatwedo-wordpress.php
@@ -5,5 +5,5 @@ declare(strict_types=1);
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return static function (ECSConfig $ecsConfig): void {
-    $ecsConfig->sets([__DIR__.'/whatwedo-common.php']);
+    $ecsConfig->sets([__DIR__ . '/whatwedo-common.php']);
 };

--- a/ecs.php
+++ b/ecs.php
@@ -6,7 +6,7 @@ use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->paths([
-        __DIR__.'/',
+        __DIR__ . '/',
     ]);
     $ecsConfig->import('config/whatwedo-common.php');
 };


### PR DESCRIPTION
There's a spacing between dots following PSR-12. (https://www.php-fig.org/psr/psr-12/#62-binary-operators).
Symfony isn't following that rule (https://symfony.com/doc/current/contributing/code/standards.html#structure).

We adjust that inside the specific configs.