### PR TITLE
chore(deps): update dependencies to latest versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     ],
     "require": {
         "php": ">=7.4",
-        "kubawerlos/php-cs-fixer-custom-fixers": "^3.0",
-        "slevomat/coding-standard": "^8.5",
-        "symplify/easy-coding-standard": "^12.1"
+        "kubawerlos/php-cs-fixer-custom-fixers": "^v3.32.0",
+        "slevomat/coding-standard": "^8.20.0",
+        "symplify/easy-coding-standard": "^12.5.23"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Sali,

This package seams to be incompatible with php 8.4 property hooks.
So, I updated all packages to the latest version.

