### PR TITLE
slevomat/coding-standard: require ~8.22.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=7.4",
         "kubawerlos/php-cs-fixer-custom-fixers": "^v3.32.0",
-        "slevomat/coding-standard": "^8.20.0",
+        "slevomat/coding-standard": "~8.22.1",
         "symplify/easy-coding-standard": "^12.5.23"
     },
     "autoload": {


### PR DESCRIPTION
otherwise you get:

vendor/bin/ecs check src
PHP Fatal error:  Declaration of SlevomatCodingStandard\Sniffs\Commenting\ForbiddenAnnotationsSniff::process(PHP_CodeSniffer\Files\File $phpcsFile, int $docCommentOpenPointer): void must be compatible with PHP_CodeSniffer\Sniffs\Sniff::process(PHP_CodeSniffer\Files\File $phpcsFile, $stackPtr) in /Users/timobuhlmann/projects/symfony-project/vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Commenting/ForbiddenAnnotationsSniff.php on line 41

cc: @SaraLuethi